### PR TITLE
Add missing parameter in connection.escape()

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ class ConnectionAwait {
    * @signature escape(data)
    * @description Pass along functionality of escape.
    */
-  escape() {
+  escape(data) {
     return this.connection.escape(data);
   }
   


### PR DESCRIPTION
When attempting to escape an SQL string using `connection.escape()`, an error is thrown saying that `data` is not defined on line 238 in `index.js`, which is caused by a missing `data` parameter in the function header of the `escape()` method. This pull request fixes the issue by adding the missing parameter at line 237 of `index.js`.